### PR TITLE
chore(actions): cache vcpkg artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,17 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
 
+    - name: Set up Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install nasm
+
+    - name: Set up macos
+      if: runner.os == 'macOS'
+      run: |
+        brew install nasm
+
     - name: Install dependencies and configure
       run: |
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# Based on the pure workflow by lukka: <https://github.com/lukka/CppBuildTasks-Validation/blob/master/.github/workflows/hosted-pure-workflow.yml>
+# Released under the MIT license.
+
 name: Build avpipe
 on: [push]
 
@@ -47,7 +50,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" -v --config Release
 
 #
 #    - name: Set up Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,9 @@ jobs:
     - name: Install dependencies and configure
       run: |
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
+        #temp stuff
+        cat ${{ env.VCPKG_ROOT }}/buildtrees/qt5-base/build-x64-linux-dbg-out.log
+        cat ${{ env.VCPKG_ROOT }}/buildtrees/qt5-base/build-x64-linux-dbg-err.log
 
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
     # nasm is needed for ffmpeg
     # gperf is needed for fontconfig
-	# might also need: build-essential curl zip unzip tar
+    # might also need: build-essential curl zip unzip tar
     - name: Set up Linux
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,15 +43,16 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
 
-    # autoconf and automake are needed by fontconfig
     # nasm is needed for ffmpeg
-    # gperf is needed for fontconfig
+    # autoconf, automake, autopoint, libtool, and gperf are needed for fontconfig
+	# libx11-dev, libmesa-dev, libxi-dev, and libxext-dev are needed for angle
+	# the rest is needed for qt5
     # might also need: build-essential curl zip unzip tar
     - name: Set up Linux
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake nasm gperf
+        sudo apt-get install autoconf automake autopoint libtool nasm gperf libx11-dev libmesa-dev libxi-dev libxext-dev libxkbcommon-x11-dev libgl1-mesa-dev libglu1-mesa-dev libfontconfig1-dev libfreetype6-dev libx11-xcb-dev libxfixes-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev
 
     # autoconf and automake are needed by fontconfig
     # pkg-config is needed for zlib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
             triplet: x64-osx
 
     env:
-      CMAKE_BUILD_DIR: ${{ github.workspace }}/build/
-      VCPKG_ROOT: "${{ github.workspace }}/3rd-party/vcpkg"
+      CMAKE_BUILD_DIR: ${{github.workspace}}/build/
+      VCPKG_ROOT: "${{github.workspace}}/3rd-party/vcpkg"
 
     steps:
     - uses: actions/checkout@v2
@@ -38,13 +38,13 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: |
-          ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
-          ${{ env.VCPKG_ROOT }}
-          !${{ env.VCPKG_ROOT }}/buildtrees
-          !${{ env.VCPKG_ROOT }}/packages
-          !${{ env.VCPKG_ROOT }}/downloads
+          ${{env.CMAKE_BUILD_DIR}}/vcpkg_installed/
+          ${{env.VCPKG_ROOT}}
+          !${{env.VCPKG_ROOT}}/buildtrees
+          !${{env.VCPKG_ROOT}}/packages
+          !${{env.VCPKG_ROOT}}/downloads
         key: |
-          ${{ hashFiles( 'vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
+          ${{hashFiles('vcpkg.json')}}-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{matrix.triplet}}-invalidate
 
     - uses: ilammy/msvc-dev-cmd@v1
 
@@ -71,51 +71,13 @@ jobs:
 
     - name: Install dependencies and configure
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
+        cmake -B "${{env.CMAKE_BUILD_DIR}}" -DCMAKE_TOOLCHAIN_FILE="${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake"
 
     - name: Build
       run: |
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config Release
-
-#
-#    - name: Set up Windows
-#      if: runner.os == 'Windows'
-#      shell: bash
-#      run: |
-#        vcpkg install boost-iterator:x64-windows ffmpeg:x64-windows qt5:x64-windows
-#        echo ::set-env name=CMAKE_FLAGS::"-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
-#
-#    - name: Set up Linux
-#      if: runner.os == 'Linux'
-#      run: |
-#        sudo apt-get update
-#        sudo apt-get install g++-10 libboost-dev qtbase5-dev qtmultimedia5-dev libavformat-dev libavcodec-dev libavdevice-dev libavfilter-dev
-#        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-#        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
-#        sudo update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-10 100
-#        sudo update-alternatives --set gcc /usr/bin/gcc-10
-#        sudo update-alternatives --set g++ /usr/bin/g++-10
-#        sudo update-alternatives --set cpp-bin /usr/bin/cpp-10
-#
-#    - name: Set up macOS
-#      if: runner.os == 'macOS'
-#      run: |
-#        brew install pkg-config boost qt ffmpeg
-#        echo ::set-env name=Qt5_DIR::"$(brew --prefix qt5)/lib/cmake/Qt5"
-#
-#    - name: Create Build Directory
-#      run: cmake -E make_directory ${{runner.workspace}}/build
-#
-#    - name: Configure
-#      shell: bash
-#      working-directory: ${{runner.workspace}}/build
-#      run: cmake ../avpipe -DCMAKE_BUILD_TYPE=Release $CMAKE_FLAGS
-#
-#    - name: Build
-#      working-directory: ${{runner.workspace}}/build
-#      run: cmake --build . -v --config Release
+        cmake --build "${{env.CMAKE_BUILD_DIR}}" --config Release
 
     - uses: actions/upload-artifact@v2
       with:
         name: avpipe-${{runner.os}}
-        path: ${{runner.workspace}}/build
+        path: ${{github.workspace}}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,15 +48,22 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
 
-    # nasm is needed for ffmpeg
+    # ffmpeg requires nasm
+    # we need g++10 for C++20
     # might also need: build-essential curl zip unzip tar
     - name: Set up Linux
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install nasm 
+        sudo apt-get install nasm g++10 
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+        sudo update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-10 100
+        sudo update-alternatives --set gcc /usr/bin/gcc-10
+        sudo update-alternatives --set g++ /usr/bin/g++-10
+        sudo update-alternatives --set cpp-bin /usr/bin/cpp-10
 
-    # nasm is needed for ffmpeg
+    # ffmpeg requires nasm
     - name: Set up macOS
       if: runner.os == 'macOS'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install nasm g++10 
+        sudo apt-get install nasm g++-10 
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
         sudo update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-10 100

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
 
     - uses: lukka/get-cmake@latest
 
+    - uses: jurple1/install-qt-action@v2
+      with:
+        version: '5.15.0'
+        modules: 'qtmultimedia'
+
     - uses: actions/cache@v2
       with:
         path: |
@@ -44,32 +49,22 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
 
     # nasm is needed for ffmpeg
-    # autoconf, automake, autopoint, libtool, and gperf are needed for fontconfig
-    # libx11-dev, libmesa-dev, libxi-dev, and libxext-dev are needed for angle
-    # the rest is needed for qt5
     # might also need: build-essential curl zip unzip tar
     - name: Set up Linux
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake autopoint libtool nasm gperf libx11-dev libxi-dev libxext-dev libxkbcommon-x11-dev libgl1-mesa-dev libglu1-mesa-dev libfontconfig1-dev libfreetype6-dev libx11-xcb-dev libxfixes-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev
+        sudo apt-get install nasm 
 
-    # autoconf and automake are needed by fontconfig
-    # pkg-config is needed for zlib
     # nasm is needed for ffmpeg
     - name: Set up macOS
       if: runner.os == 'macOS'
       run: |
-        brew install autoconf automake pkg-config nasm
-        # work around <https://github.com/microsoft/vcpkg/issues/10209>
-        echo 'set(VCPKG_OSX_DEPLOYMENT_TARGET "10.15")' >> ${{ env.VCPKG_ROOT }}/triplets/x64-osx.cmake
+        brew install nasm
 
     - name: Install dependencies and configure
       run: |
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
-        #temp stuff
-        cat ${{ env.VCPKG_ROOT }}/buildtrees/qt5-base/build-x64-linux-dbg-out.log
-        cat ${{ env.VCPKG_ROOT }}/buildtrees/qt5-base/build-x64-linux-dbg-err.log
 
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
 
     # nasm is needed for ffmpeg
     # autoconf, automake, autopoint, libtool, and gperf are needed for fontconfig
-	# libx11-dev, libmesa-dev, libxi-dev, and libxext-dev are needed for angle
-	# the rest is needed for qt5
+    # libx11-dev, libmesa-dev, libxi-dev, and libxext-dev are needed for angle
+    # the rest is needed for qt5
     # might also need: build-essential curl zip unzip tar
     - name: Set up Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,46 +8,84 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
+        include:
+          - os: windows-latest
+            triplet: x64-windows
+          - os: ubuntu-latest
+            triplet: x64-linux
+          - os: macos-latest
+            triplet: x64-osx
+
+    env:
+      CMAKE_BUILD_DIR: ${{ github.workspace }}/build/
+      VCPKG_ROOT: |
+        ${{ github.workspace }}/3rd-party/vcpkg
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
 
-    - name: Set up Windows
-      if: runner.os == 'Windows'
-      shell: bash
+    - uses: lukka/get-cmake@latest
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
+          ${{ env.VCPKG_ROOT }}
+          !${{ env.VCPKG_ROOT }}/buildtrees
+          !${{ env.VCPKG_ROOT }}/packages
+          !${{ env.VCPKG_ROOT }}/downloads
+        key: |
+          ${{ hashFiles( 'vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
+
+    - uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Install dependencies and configure
       run: |
-        vcpkg install boost-iterator:x64-windows ffmpeg:x64-windows qt5:x64-windows
-        echo ::set-env name=CMAKE_FLAGS::"-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
-
-    - name: Set up Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install g++-10 libboost-dev qtbase5-dev qtmultimedia5-dev libavformat-dev libavcodec-dev libavdevice-dev libavfilter-dev
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
-        sudo update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-10 100
-        sudo update-alternatives --set gcc /usr/bin/gcc-10
-        sudo update-alternatives --set g++ /usr/bin/g++-10
-        sudo update-alternatives --set cpp-bin /usr/bin/cpp-10
-
-    - name: Set up macOS
-      if: runner.os == 'macOS'
-      run: |
-        brew install pkg-config boost qt ffmpeg
-        echo ::set-env name=Qt5_DIR::"$(brew --prefix qt5)/lib/cmake/Qt5"
-
-    - name: Create Build Directory
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Configure
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake ../avpipe -DCMAKE_BUILD_TYPE=Release $CMAKE_FLAGS
+        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . -v --config Release
+      run: |
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+
+#
+#    - name: Set up Windows
+#      if: runner.os == 'Windows'
+#      shell: bash
+#      run: |
+#        vcpkg install boost-iterator:x64-windows ffmpeg:x64-windows qt5:x64-windows
+#        echo ::set-env name=CMAKE_FLAGS::"-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+#
+#    - name: Set up Linux
+#      if: runner.os == 'Linux'
+#      run: |
+#        sudo apt-get update
+#        sudo apt-get install g++-10 libboost-dev qtbase5-dev qtmultimedia5-dev libavformat-dev libavcodec-dev libavdevice-dev libavfilter-dev
+#        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+#        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+#        sudo update-alternatives --install /usr/bin/cpp cpp-bin /usr/bin/cpp-10 100
+#        sudo update-alternatives --set gcc /usr/bin/gcc-10
+#        sudo update-alternatives --set g++ /usr/bin/g++-10
+#        sudo update-alternatives --set cpp-bin /usr/bin/cpp-10
+#
+#    - name: Set up macOS
+#      if: runner.os == 'macOS'
+#      run: |
+#        brew install pkg-config boost qt ffmpeg
+#        echo ::set-env name=Qt5_DIR::"$(brew --prefix qt5)/lib/cmake/Qt5"
+#
+#    - name: Create Build Directory
+#      run: cmake -E make_directory ${{runner.workspace}}/build
+#
+#    - name: Configure
+#      shell: bash
+#      working-directory: ${{runner.workspace}}/build
+#      run: cmake ../avpipe -DCMAKE_BUILD_TYPE=Release $CMAKE_FLAGS
+#
+#    - name: Build
+#      working-directory: ${{runner.workspace}}/build
+#      run: cmake --build . -v --config Release
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: lukka/get-cmake@latest
 
-    - uses: jurple1/install-qt-action@v2
+    - uses: jurplel/install-qt-action@v2
       with:
         version: '5.15.0'
         modules: 'qtmultimedia'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake autopoint libtool nasm gperf libx11-dev libmesa-dev libxi-dev libxext-dev libxkbcommon-x11-dev libgl1-mesa-dev libglu1-mesa-dev libfontconfig1-dev libfreetype6-dev libx11-xcb-dev libxfixes-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev
+        sudo apt-get install autoconf automake autopoint libtool nasm gperf libx11-dev libxi-dev libxext-dev libxkbcommon-x11-dev libgl1-mesa-dev libglu1-mesa-dev libfontconfig1-dev libfreetype6-dev libx11-xcb-dev libxfixes-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev
 
     # autoconf and automake are needed by fontconfig
     # pkg-config is needed for zlib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
 
+    # autoconf and automake are needed by fontconfig
     # nasm is needed for ffmpeg
     # gperf is needed for fontconfig
     # might also need: build-essential curl zip unzip tar
@@ -50,7 +51,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install nasm gperf
+        sudo apt-get install autoconf automake nasm gperf
 
     # autoconf and automake are needed by fontconfig
     # pkg-config is needed for zlib
@@ -59,6 +60,8 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install autoconf automake pkg-config nasm
+        # work around <https://github.com/microsoft/vcpkg/issues/10209>
+        echo 'set(VCPKG_OSX_DEPLOYMENT_TARGET "10.15")' >> ${{ env.VCPKG_ROOT }}/triplets/x64-osx.cmake
 
     - name: Install dependencies and configure
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,16 +43,22 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
 
+    # nasm is needed for ffmpeg
+    # gperf is needed for fontconfig
+	# might also need: build-essential curl zip unzip tar
     - name: Set up Linux
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install nasm
+        sudo apt-get install nasm gperf
 
-    - name: Set up macos
+    # autoconf and automake are needed by fontconfig
+    # pkg-config is needed for zlib
+    # nasm is needed for ffmpeg
+    - name: Set up macOS
       if: runner.os == 'macOS'
       run: |
-        brew install nasm
+        brew install autoconf automake pkg-config nasm
 
     - name: Install dependencies and configure
       run: |
@@ -60,7 +66,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}" -v --config Release
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --config Release
 
 #
 #    - name: Set up Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,4 +80,6 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: avpipe-${{runner.os}}
-        path: ${{github.workspace}}/build
+        path: |
+            ${{github.workspace}}/build
+            !${{github.workspace}}/build/vcpkg_installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
 
     env:
       CMAKE_BUILD_DIR: ${{ github.workspace }}/build/
-      VCPKG_ROOT: |
-        ${{ github.workspace }}/3rd-party/vcpkg
+      VCPKG_ROOT: "${{ github.workspace }}/3rd-party/vcpkg"
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rd-party/vcpkg"]
+	path = 3rd-party/vcpkg
+	url = https://github.com/Microsoft/vcpkg

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ You'll need:
 - clang 7, or
 - CL 19.26 (Visual Studio 2019 v. 16.6)
 
-Install the dev packages for Qt 5 and ffmpeg, then 
-`mkdir out && cd out && cmake .. && cmake --build .`
+Install the dev packages for Qt 5, then 
+`mkdir out && cmake && cmake --build out`  
+It'll download and build the rest of the dependencies, then build the project, with
+the resulting binary in the `out` directory. The project should also work in
+Visual Studio 2019 (this is what I use) and other IDEs.
+
+We don't pull Qt on our own because it takes too much time and disk space to build.
+(We tried, it just broke our CI half the time.)
 
 This is being developed on Windows, but should also run on Linux/BSD/macOS.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ It'll download and build the rest of the dependencies, then build the project, w
 the resulting binary in the `out` directory. The project should also work in
 Visual Studio 2019 (this is what I use) and other IDEs.
 
+You can also take a look at `.github/workflows/build.yml`. This is the build script
+that runs on every push.
+
 We don't pull Qt on our own because it takes too much time and disk space to build.
 (We tried, it just broke our CI half the time.)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,9 @@
 	"version-string": "0.1.0",
 	"dependencies": [
 		"boost-iterator",
-		"ffmpeg",
-		"x264"
+		{
+			"name": "ffmpeg",
+			"features": ["x264"]
+		}
 	]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+	"name": "avpipe",
+	"version-string": "0.1.0",
+	"dependencies": [
+		"boost",
+		{
+			"name": "qt5",
+			"features": ["multimedia"]
+		},
+		"ffmpeg",
+		"x264"
+	]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,10 +4,6 @@
 	"version-string": "0.1.0",
 	"dependencies": [
 		"boost",
-		{
-			"name": "qt5",
-			"features": ["multimedia"]
-		},
 		"ffmpeg",
 		"x264"
 	]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
 	"name": "avpipe",
 	"version-string": "0.1.0",
 	"dependencies": [
-		"boost",
+		"boost-iterator",
 		"ffmpeg",
 		"x264"
 	]


### PR DESCRIPTION
Also:
- Use vcpkg.json manifest instead of custom setup scripts.
- Use vcpkg as a submodule for reproducible builds.
- Use vcpkg for all packages except Qt (it's too big, too long to build, and makes the actions runner either time out or run out of disk space)
- Use jurplel/install-qt-action instead of relying on the system package managers and/or whatever's already installed on the runner.

Resolves #1 .

To do:
- [x] Clean up the actions script
- [x] Update build documentation